### PR TITLE
only set up ssh tunnel if configuration provides one

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,6 @@ SLACK_WEBHOOK=xxx
 
 If you have any trouble, get in touch with a developer who has had their environment configured. They'll provide the bucket name and host, and setup an IAM account if needed.
 
-Before you can deploy, make sure you have your SSH key added to ssh-agent. You may do this by executing the following:
-
-```bash
-ssh-add ~/.ssh/id_rsa
-```
-
-See https://developer.github.com/guides/using-ssh-agent-forwarding/ for more information about SSH agent forwarding.
-
 We use `ember-cli-deploy` to deploy our assets. Provided is a short list that covers deployment of 99% of our use cases. For more information see [ember-cli/ember-cli-deploy](https://github.com/ember-cli/ember-cli-deploy).
 
 ```bash

--- a/blueprints/ink-deploy-config/files/config/deploy.js
+++ b/blueprints/ink-deploy-config/files/config/deploy.js
@@ -42,13 +42,8 @@ module.exports = function (deployTarget) {
 
     'redis': {
       allowOverwrite: true,
-      keyPrefix: '<%= dasherizedPackageName %>'
-    },
-
-    'ssh-tunnel': {
-      username: 'deploy',
-      host: env('REDIS_HOST'),
-      privateKeyPath: null
+      keyPrefix: '<%= dasherizedPackageName %>',
+      url: env('REDIS_HOST')
     },
 
     's3': {

--- a/lib/ember-cli-deploy-ink-plugin/index.js
+++ b/lib/ember-cli-deploy-ink-plugin/index.js
@@ -34,7 +34,7 @@ module.exports = {
 
       setup: function (context) {
         var config = context.config;
-        if (config.build.environment !== 'development') {
+        if (config['ssh-tunnel']) {
           config.redis.url = 'redis://127.0.0.1:' + context.tunnel.srcPort + '/';
         }
       },

--- a/lib/ember-cli-deploy-ink-plugin/index.js
+++ b/lib/ember-cli-deploy-ink-plugin/index.js
@@ -32,13 +32,6 @@ module.exports = {
     return {
       name: 'ink',
 
-      setup: function (context) {
-        var config = context.config;
-        if (config['ssh-tunnel']) {
-          config.redis.url = 'redis://127.0.0.1:' + context.tunnel.srcPort + '/';
-        }
-      },
-
       willDeploy: function (context) {
         var buildContext = process.env['TRAVIS'] ? this.buildCiContext(context) : this.buildContext(context);
         return RSVP.hash(buildContext).then(function (ctx) {

--- a/lib/ember-cli-deploy-ink-plugin/package.json
+++ b/lib/ember-cli-deploy-ink-plugin/package.json
@@ -3,10 +3,5 @@
   "keywords": [
     "ember-addon",
     "ember-cli-deploy-plugin"
-  ],
-  "ember-addon": {
-    "after": [
-      "ember-cli-deploy-ssh-tunnel"
-    ]
-  }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "ember-cli-deploy-redis": "^0.1.0",
     "ember-cli-deploy-revision-data": "^0.1.0",
     "ember-cli-deploy-s3": "^0.1.0",
-    "ember-cli-deploy-ssh-tunnel": "^0.2.0",
     "node-slackr": "^0.1.2",
     "rsvp": "^3.1.0"
   },


### PR DESCRIPTION
Right now we do it for all non-dev environments, but we'd like to get rid of the ssh tunnel so this is the first step. The next step would be to remove 'ssh-tunnel' from config/deploy.js.