### PR TITLE
Rest api

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,6 @@ SLACK_WEBHOOK=xxx
 
 If you have any trouble, get in touch with a developer who has had their environment configured. They'll provide the bucket name and host, and setup an IAM account if needed.
 
-Before you can deploy, make sure you have your SSH key added to ssh-agent. You may do this by executing the following:
-
-```bash
-ssh-add ~/.ssh/id_rsa
-```
-
-See https://developer.github.com/guides/using-ssh-agent-forwarding/ for more information about SSH agent forwarding.
-
 We use `ember-cli-deploy` to deploy our assets. Provided is a short list that covers deployment of 99% of our use cases. For more information see [ember-cli/ember-cli-deploy](https://github.com/ember-cli/ember-cli-deploy).
 
 ```bash

--- a/blueprints/ink-deploy-config/files/config/deploy.js
+++ b/blueprints/ink-deploy-config/files/config/deploy.js
@@ -42,13 +42,8 @@ module.exports = function (deployTarget) {
 
     'redis': {
       allowOverwrite: true,
-      keyPrefix: '<%= dasherizedPackageName %>'
-    },
-
-    'ssh-tunnel': {
-      username: 'deploy',
-      host: env('REDIS_HOST'),
-      privateKeyPath: null
+      keyPrefix: '<%= dasherizedPackageName %>',
+      url: env('REDIS_HOST')
     },
 
     's3': {

--- a/blueprints/ink-deploy-config/files/config/deploy.js
+++ b/blueprints/ink-deploy-config/files/config/deploy.js
@@ -17,10 +17,11 @@ module.exports = function (deployTarget) {
       'revision-data': {
         type: 'git-commit'
       },
-      'redis': {
-        allowOverwrite: true,
-        keyPrefix: '<%= dasherizedPackageName %>',
-        url: 'redis://127.0.0.1:6379/'
+
+      'rest': {
+        baseUrl: 'http://example.com/change-me',
+        username: 'deploy',
+        password: 'none'
       }
     };
   }
@@ -40,10 +41,10 @@ module.exports = function (deployTarget) {
       type: 'git-commit'
     },
 
-    'redis': {
-      allowOverwrite: true,
-      keyPrefix: '<%= dasherizedPackageName %>',
-      url: env('REDIS_HOST')
+    'rest': {
+      baseUrl: env('REST_URL'),
+      username: env('REST_USERNAME'),
+      password: env('REST_PASSWORD')
     },
 
     's3': {

--- a/lib/ember-cli-deploy-ink-plugin/index.js
+++ b/lib/ember-cli-deploy-ink-plugin/index.js
@@ -34,7 +34,7 @@ module.exports = {
 
       setup: function (context) {
         var config = context.config;
-        if (config.build.environment !== 'development') {
+        if (config['ssh-tunnel']) {
           config.redis.url = 'redis://127.0.0.1:' + context.tunnel.srcPort + '/';
         }
       },

--- a/lib/ember-cli-deploy-ink-plugin/index.js
+++ b/lib/ember-cli-deploy-ink-plugin/index.js
@@ -32,13 +32,6 @@ module.exports = {
     return {
       name: 'ink',
 
-      setup: function (context) {
-        var config = context.config;
-        if (config['ssh-tunnel']) {
-          config.redis.url = 'redis://127.0.0.1:' + context.tunnel.srcPort + '/';
-        }
-      },
-
       willDeploy: function (context) {
         var buildContext = process.env['TRAVIS'] ? this.buildCiContext(context) : this.buildContext(context);
         return RSVP.hash(buildContext).then(function (ctx) {

--- a/lib/ember-cli-deploy-ink-plugin/package.json
+++ b/lib/ember-cli-deploy-ink-plugin/package.json
@@ -3,10 +3,5 @@
   "keywords": [
     "ember-addon",
     "ember-cli-deploy-plugin"
-  ],
-  "ember-addon": {
-    "after": [
-      "ember-cli-deploy-ssh-tunnel"
-    ]
-  }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-deploy-ink-pack",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "An opinionated collection of ember-cli-deploy plugins for continuous deployment.",
   "repository": "https://github.com/movableink/ember-cli-deploy-ink-pack.git",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "ember-cli-deploy-redis": "^0.1.0",
     "ember-cli-deploy-revision-data": "^0.1.0",
     "ember-cli-deploy-s3": "^0.1.0",
-    "ember-cli-deploy-ssh-tunnel": "^0.2.0",
     "node-slackr": "^0.1.2",
     "rsvp": "^3.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -15,15 +15,15 @@
     "ember-cli-deploy-display-revisions": "^0.1.0",
     "ember-cli-deploy-gzip": "^0.1.0",
     "ember-cli-deploy-manifest": "^0.1.0",
-    "ember-cli-deploy-redis": "^0.1.0",
     "ember-cli-deploy-revision-data": "^0.1.0",
+    "ember-cli-deploy-rest": "^1.0.0",
     "ember-cli-deploy-s3": "^0.1.0",
     "node-slackr": "^0.1.2",
     "rsvp": "^3.1.0"
   },
   "devDependencies": {
-    "ember-cli": "1.13.5",
-    "ember-cli-release": "0.2.3"
+    "ember-cli": "2.6.2",
+    "ember-cli-release": "0.2.9"
   },
   "ember-addon": {
     "defaultBlueprint": "ink-deploy-config",


### PR DESCRIPTION
This switches out ember-cli-deploy-redis with ember-cli-deploy-rest.

This is so that we can deploy from travis without opening our redis servers to the outside world.